### PR TITLE
Implement multiline sentry push

### DIFF
--- a/src/Command/PushCommand.php
+++ b/src/Command/PushCommand.php
@@ -54,9 +54,15 @@ class PushCommand extends Command
         $progress = new ProgressBar($output, $logFileParser->count());
         $progress->start();
 
-        foreach ($logFileParser->getEntries() as $entry) {
-            $sentryPusher->push($entry, $typeToLevel);
-            $progress->advance();
+        if (Parser::TYPE_FORMLESS === $input->getOption('logfile-type')) {
+            $sentryPusher->pushMultiline($logFileParser->getEntries(), $typeToLevel);
+        }
+
+        if (Parser::TYPE_FORMLESS !== $input->getOption('logfile-type')) {
+            foreach ($logFileParser->getEntries() as $entry) {
+                $sentryPusher->push($entry, $typeToLevel);
+                $progress->advance();
+            }
         }
 
         $progress->finish();


### PR DESCRIPTION
hey move-elevator,

fomless log files should not be pushed as single lines. 

Example:
![image](https://cloud.githubusercontent.com/assets/5803630/18917635/a7c32d34-8598-11e6-9db0-a504ffddb8ba.png)

If you push this one to sentry with the SentryPusher u create 5 single events. 

Looks like this:
![image](https://cloud.githubusercontent.com/assets/5803630/18917924/64d28f14-8599-11e6-911d-6288e4ea0117.png)

With my solution u create the following:

<img width="944" alt="bildschirmfoto 2016-09-29 um 12 24 04" src="https://cloud.githubusercontent.com/assets/5803630/18950469/4265a932-8640-11e6-89fc-252784aa5af8.PNG">

kind regards,
Sebastian
